### PR TITLE
Update kibana.yml.j2

### DIFF
--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -29,7 +29,9 @@ elasticsearch.shardTimeout: 60000
 
 telemetry.enabled: false
 
+{%if kibana_version < "8.0.0" %}
 xpack.security.enabled: true
+{% endif %}
 xpack.security.encryptionKey: "{{kibana_security_encryptionkey}}"
 xpack.encryptedSavedObjects.encryptionKey: '{{kibana_savedobjects_encryptionkey}}'
 xpack.reporting.encryptionKey: '{{kibana_reporting_encryptionkey}}'


### PR DESCRIPTION
Hi it seems like I forgot the security.enabled part in my last pr since this is also no longer needed after version 8.0.0.

security no longer needed in version 8.0.0 is set by default